### PR TITLE
disabling nfs sync and enabling rsync

### DIFF
--- a/vagrant/Vagrantfile
+++ b/vagrant/Vagrantfile
@@ -293,7 +293,8 @@ Vagrant.configure(VAGRANTFILE_API_VERSION) do |config|
 	#
 	#	sync type
 	#
-	config.vm.synced_folder './', '/vagrant', type: sync	# nfs, rsync
+	# config.vm.synced_folder './', '/vagrant', type: sync	# nfs, rsync
+	config.vm.synced_folder "./", "/vagrant", type: "rsync"
 
 	#
 	#	cache


### PR DESCRIPTION
This allows users to rsync data from the host machine into the Vagrant VM by issuing either "vagrant reload" or "vagrant rsync".  Also, if the user wants, they can issue a "vagrant rsync-auto" and Vagrant handles sync'ing all the data automatically.  Pulled from:

http://www.vagrantup.com/blog/feature-preview-vagrant-1-5-rsync.html
