### PR TITLE
Fix libvirt network name conflict

### DIFF
--- a/vagrant/Vagrantfile
+++ b/vagrant/Vagrantfile
@@ -500,7 +500,7 @@ Vagrant.configure(VAGRANTFILE_API_VERSION) do |config|
 			:ip => range2[offset2+i].to_s,
 			:libvirt__netmask => netmask2,
 			#:libvirt__dhcp_enabled => false,	# XXX: not allowed here
-			:libvirt__network_name => 'default'
+			:libvirt__network_name => 'omv-default'
 
 			# this is the real network that we'll use...
 			vm.vm.network :private_network,


### PR DESCRIPTION
Management network defined around lines 36-41 is using 192.168.145.0/24
network address, and then 'default' as the network name.
Libvirt (on Fedora 20 at least) is using 192.168.100.0/24 network with
the same name, which causes OMV to fail during "vagrant up".
"virsh net-destroy/net-undefine default" is not a solution, since
one might actually use 'default' network already.
Proper fix is to either use network2 = IPAddr.new '192.168.100.0/24',
or use own name for the mgmt network.
This patch implements the 2nd solution.
