### PR TITLE
Check the CWD for an omv.yaml file.

### DIFF
--- a/vagrant/Vagrantfile
+++ b/vagrant/Vagrantfile
@@ -162,6 +162,12 @@ if File.exist?(f)
 	if File.exist?(ff)
 		f = ff
 	end
+
+	# Check the CWD for an omv.yaml
+	ff = File.join('.', 'omv.yaml')
+	if File.exist?(ff)
+		f = ff
+	end
 end
 
 # load settings


### PR DESCRIPTION
In working to make it possible to use OMV without depending on subdirectories, it is necessary to have it look in the current working directory to find an omv.yaml file.

This means that you can put your project folder elsewhere on the filesystem than under your OMV checkout if you also set the environment variable VAGRANT_CWD to point to your checkout of OMV's vagrant folder containing the OMV Vagrantfile.