### PR TITLE
Ansible provisioner: various fixes

### DIFF
--- a/vagrant/Vagrantfile
+++ b/vagrant/Vagrantfile
@@ -1214,6 +1214,8 @@ Vagrant.configure(VAGRANTFILE_API_VERSION) do |config|
 						# reverse the mapping, so that the groups enumerate their hosts
 						ansible.groups = Hash[ansible_groups.values.flatten.uniq.map { |i| [i, ansible_groups.select{|_,v| not(v.nil?) and v.include?(i) }.keys ]}]
 						ansible.host_key_checking = false
+						ansible.limit = 'all'
+						ansible.extra_vars = { ansible_ssh_user: 'root' }
 					end
 				end
 			end


### PR DESCRIPTION
By default Vagrant runs Ansible provisioner limited to single host.
This prevents us to get facts from other hosts - which makes it
impossible to provision clustered environment with OMV and Ansible.

"ansible.limit = 'all'" resolves this.

Additionally, most of Ansible roles/playbooks are designed to be run
under 'root' system account. To avoid un-needed playbooks modifications
and adding "sudo: yes" here and there, we explicitly tell Vagrant to use
'root' when it runs Ansible provisioning.