### PR TITLE
Allow Libvirt provisioner custom settings

### DIFF
--- a/vagrant/Vagrantfile
+++ b/vagrant/Vagrantfile
@@ -98,6 +98,14 @@ reboot = false			# reboot the box after provisioning; requires vagrant-reload pl
 unsafe = false			# true will trade data safety for performance gains
 nested = false			# should we allow vm nesting
 comment = ''			# store a comment field in the omv.yaml file
+#libvirt-specific provisioner settings
+libvirt_settings = {
+	'graphics_type' => 'spice',
+	'video_type' => 'qxl',
+	'connect_via_ssh' => false,
+	'username' => 'root',
+	'storage_pool_name' => 'default',
+}	# libvirt-specific provisioner settings
 
 def array_values_to_array_of_hashes(l)
 	result = l
@@ -216,6 +224,9 @@ if File.exist?(f)
 	cachier = settings[:cachier]
 	if settings[:vms].is_a?(Array)
 		vms = settings[:vms]
+	end
+	if settings[:libvirt].is_a?(Hash)
+		libvirt_settings.merge(settings[:libvirt])
 	end
 	namespace = settings[:namespace]
 	count = settings[:count]
@@ -542,6 +553,15 @@ while skip < ARGV.length
 			really_use_rm_once = false
 		end
 
+	elsif ARGV[skip].start_with?(arg='--omv-libvirt-')
+		v = ARGV.delete_at(skip).dup
+		v.slice! arg
+        v.tr! '-','_'
+        option, value = v.split('=')
+        if libvirt_settings.keys.include?(option)
+            libvirt_settings[option] = value
+        end
+
 	else	# skip over "official" vagrant args
 		skip = skip + 1
 	end
@@ -582,6 +602,7 @@ settings = {
 	:nested => nested,
 	:comment => comment,
 	:reallyrm => really_use_rm.nil?? 'nil' : really_use_rm,
+	:libvirt => libvirt_settings,
 }
 File.open(f, 'w') do |file|
 	file.write settings.to_yaml
@@ -1516,14 +1537,14 @@ Vagrant.configure(VAGRANTFILE_API_VERSION) do |config|
 	#	libvirt
 	#
 	config.vm.provider :libvirt do |libvirt|
-		libvirt.driver = 'kvm'	# needed for kvm performance benefits !
-		libvirt.graphics_type = 'spice'
-		libvirt.video_type = 'qxl'
+		libvirt.driver = libvirt_settings['driver']	# needed for kvm performance benefits !
+		libvirt.graphics_type = libvirt_settings['graphics_type']
+		libvirt.video_type = libvirt_settings['video_type']
 		# leave out to connect directly with qemu:///system
 		#libvirt.host = 'localhost'
 		libvirt.connect_via_ssh = false
 		libvirt.username = 'root'
-		libvirt.storage_pool_name = 'default'
+		libvirt.storage_pool_name = libvirt_settings['storage_pool_name']
 		#libvirt.default_network = 'default'	# XXX: this does nothing
 		libvirt.default_prefix = "#{namespace}"	# set a prefix for your vm's...
 	end


### PR DESCRIPTION
This is WIP for RFE #121. Not (yet) tested, so please don't yet merge, I have couple of things I don't like in this diff, and want some 2nd opinion:
* argv processing. Can't we finally rewrite command line arguments block to use getopt?
* assignments on line 1519 and further - can this be simplified somehow, or it's fine as it is?