### PR TITLE
Updated documentation: fixed header markdown

### DIFF
--- a/DOCUMENTATION.md
+++ b/DOCUMENTATION.md
@@ -1,4 +1,4 @@
-#Oh-My-Vagrant
+# Oh-My-Vagrant
 
 <!--
 This is: Oh My Vagrant!
@@ -19,13 +19,13 @@ You should have received a copy of the GNU Affero General Public License
 along with this program.  If not, see <http://www.gnu.org/licenses/>.
 -->
 
-##Oh-My-Vagrant by [James](https://ttboj.wordpress.com/)
-####Available from:
-####[https://github.com/purpleidea/oh-my-vagrant/](https://github.com/purpleidea/oh-my-vagrant/)
+## Oh-My-Vagrant by [James](https://ttboj.wordpress.com/)
+#### Available from:
+#### [https://github.com/purpleidea/oh-my-vagrant/](https://github.com/purpleidea/oh-my-vagrant/)
 
-####This documentation is available in: [Markdown](https://github.com/purpleidea/oh-my-vagrant/blob/master/DOCUMENTATION.md) or [PDF](https://pdfdoc-purpleidea.rhcloud.com/pdf/https://github.com/purpleidea/oh-my-vagrant/blob/master/DOCUMENTATION.md) format.
+#### This documentation is available in: [Markdown](https://github.com/purpleidea/oh-my-vagrant/blob/master/DOCUMENTATION.md) or [PDF](https://pdfdoc-purpleidea.rhcloud.com/pdf/https://github.com/purpleidea/oh-my-vagrant/blob/master/DOCUMENTATION.md) format.
 
-####Table of Contents
+#### Table of Contents
 
 1. [Overview](#overview)
 2. [Project description - What the project does](#project-description)
@@ -45,13 +45,13 @@ along with this program.  If not, see <http://www.gnu.org/licenses/>.
 8. [Development - Background on module development and reporting bugs](#development)
 9. [Authors - Authors and contact information](#authors)
 
-##Overview
+## Overview
 
 The Oh-My-Vagrant project lets you describe your Vagrant configuration declaratively
 in YAML, and provides a general purpose Vagrantfile that reads that configuration
 and passes it to Vagrant.
 
-##Project Description
+## Project Description
 
 Vagrant is great, but it has some rough edges, especially if you want your Vagrant
 files to work across multiple local virt providers (e.g. VirtualBox, libvirt), and
@@ -74,9 +74,9 @@ kick off docker commands, and more!
 For more information, start by reading and working through the introductory
 [blog post](https://ttboj.wordpress.com/2014/09/03/introducing-oh-my-vagrant/).
 
-##Setup
+## Setup
 
-###What can Oh-My-Vagrant do?
+### What can Oh-My-Vagrant do?
 
 Oh-My-Vagrant is designed to be able to deal with:
 
@@ -89,7 +89,7 @@ Oh-My-Vagrant is designed to be able to deal with:
 * Automatic Kubernetes setup
 * And much more...
 
-###Mainstream usage
+### Mainstream usage
 Oh-My-Vagrant now supports a "mainstream" mode. This is the most common way to
 use OMV when it is installed via your package manager. You interact with it
 entirely with the `omv` binary. The `omv` binary works exactly like the
@@ -106,7 +106,7 @@ to automatically create an `omv.yaml` file. If you supply a path as an argument
 to the init verb, then all OMV project specific files will be stored in this
 sub directory, to avoid cluttering up your project root directory.
 
-###Simple usage
+### Simple usage
 
 For most use cases, the simple usage of Oh-My-Vagrant should fulfill all your
 needs. Start by recursively cloning the project, and entering the vagrant/
@@ -132,7 +132,7 @@ command will cause one to be generated. Play around with the settings in the
 omv.yaml file, and forget about the days where small changes to your
 environment, required pasting in a mess of code.
 
-###Complex usage
+### Complex usage
 
 The complex use case allows Oh-My-Vagrant to be used as a platform that you can
 build a "module" on top of. This module can provide a homework environment, a
@@ -157,7 +157,7 @@ git master branch as often as you can.
 your author would be happy to help out in exchange for code or documentation
 patches.
 
-###Example modules
+### Example modules
 
 Example modules should be added as git submodules in a branch named:
 _module/your_module_name_. For example, if your module is called _gluster_,
@@ -168,18 +168,18 @@ possible, here is a list of examples:
 * [p4h](https://github.com/purpleidea/p4h)
 * [puppet-pushing](https://github.com/purpleidea/puppet-pushing)
 
-##Usage and frequently asked questions
+## Usage and frequently asked questions
 (Send your questions as a patch to this FAQ! I'll review it, merge it, and
 respond by commit with the answer.)
 
-###Why did you start this project?
+### Why did you start this project?
 
 I wasted enough time making custom Vagrant environments for more than one
 project. I took what I learnt about Vagrant, and generalized that in a single
 project. Now I don't have to duplicate code, or waste time when I want to make
 changes to my Vagrant environment.
 
-###Why are there multiple network interfaces created on each OMV managed host?
+### Why are there multiple network interfaces created on each OMV managed host?
 
 Each VM brought up by OMV and vagrant-libvirt typically has two interfaces by
 default. The first interface on the VM (which uses DHCP) is used to initially
@@ -193,7 +193,7 @@ prefer a consistent (statically assigned) IP address across reboots, OMV adds a
 second interface which has this statically assigned address. It also provides
 DNS for this network interface via the `/etc/hosts` file.
 
-###Why is there an extra entry in the `/etc/hosts` file on each VM?
+### Why is there an extra entry in the `/etc/hosts` file on each VM?
 
 Every VM created by OMV includes an extra entry in the `/etc/hosts` file:
 
@@ -212,7 +212,7 @@ IP address reserved on every VM in the cluster. It's unused by default and can
 be used by the developer for any purpose. It's commonly used by keepalived when
 using the VM cluster to demonstrate leader election.
 
-###Do you have any tricks for using Vagrant and Vagrant-Libvirt?
+### Do you have any tricks for using Vagrant and Vagrant-Libvirt?
 
 I've written a bunch about Vagrant and Vagrant-Libvirt on my
 [technical blog](https://ttboj.wordpress.com/). Since things have changed over
@@ -224,13 +224,13 @@ are probably still relevant, and which will be very useful. They are:
 * [Vagrant vsftp and other tricks](https://ttboj.wordpress.com/2013/12/21/vagrant-vsftp-and-other-tricks/)
 * [Vagrant clustered SSH and ‘screen’](https://ttboj.wordpress.com/2014/01/02/vagrant-clustered-ssh-and-screen/)
 
-###Can I use this without puppet?
+### Can I use this without puppet?
 
 Yes, absolutely. This provides puppet integration, but it is entirely optional.
 If you'd like to add integration for another configuration management system,
 please send a patch.
 
-###Something isn't working correctly, and I feel I'm missing some code...
+### Something isn't working correctly, and I feel I'm missing some code...
 
 This project has some useful dependencies which are included in the main
 project as git submodules. To ensure you get all of the code, make sure you do
@@ -238,7 +238,7 @@ an initial clone with the `--recursive` flag. Example:
 
 ```git clone --recursive https://github.com/purpleidea/oh-my-vagrant/```
 
-###Does this work on Windows?
+### Does this work on Windows?
 
 Almost all of the code is `vagrant` specific ruby code, therefore OMV should
 work on anything that vagrant works on. However, there is a bit of platform
@@ -249,14 +249,14 @@ testing it on that platform. So far, few have wanted to use or develop on that
 platform, with most preferring GNU/Linux and sometimes OSX, which are both
 fully functional at this time.
 
-###Awesome work, but it's missing support for a feature and/or platform!
+### Awesome work, but it's missing support for a feature and/or platform!
 
 Since this is an Open Source / Free Software project that I also give away for
 free (as in beer, free as in gratis, free as in libre), I'm unable to provide
 unlimited support. Please consider donating funds, hardware, virtual machines,
 and other resources. For specific needs, you could perhaps sponsor a feature!
 
-###I am seeing a similar error that mentions `hostmanager`. The error looks like:
+### I am seeing a similar error that mentions `hostmanager`. The error looks like:
 
 ```
 $ vagrant status
@@ -300,24 +300,24 @@ Patched successfully!
 Now you can run `vagrant status` successfully and utilize the function of the plug-in
 which allows you to modify the /etc/hosts file on each host in the cluster.
 
-###You didn't answer my question, or I have a question!
+### You didn't answer my question, or I have a question!
 
 Contact me through my [technical blog](https://ttboj.wordpress.com/contact/)
 and I'll do my best to help. If you have a good question, please remind me to
 add my answer to this documentation!
 
-##Reference
+## Reference
 Please note that there are a number of undocumented options. For more
 information on these options, please view the source at:
 [https://github.com/purpleidea/oh-my-vagrant/](https://github.com/purpleidea/oh-my-vagrant/).
 If you feel that a well used option needs documenting here, please contact me.
 
-###Overview of reference
+### Overview of reference
 * [omv.yaml](#omv.yaml): Main configuration file.
 * [Command line](#command-line): Command line parameters.
 * [oh-my-vagrant.yaml](#oh-my-vagrant.yaml): User specific configuration.
 
-###omv.yaml
+### omv.yaml
 Editing the omv.yaml file is the primary way of modifying your Oh-My-Vagrant
 environment. If you don't have a template, running the `vagrant status` command
 should cause one to get created with some sensible defaults.
@@ -328,43 +328,43 @@ the assumption that if an `omv.yaml` setting matches the name of a Vagrant box
 configuration setting, then that setting in the YAML provides arguments to
 the corresponding call in the Vagrantfile.
 
-####`domain`
+#### `domain`
 Currently undocumented.
 
-####`network`
+#### `network`
 Subnet (in CIDR notation) that will be used for virtual machines.
 If you're using Libvirt, make sure it does not clash with the existing virtual
 networks on your machine. If it does - you have to set [:namespace](#namespace)
 parameter to be the same as existing network name, otherwise things will not
 work.
 
-####`image`
+#### `image`
 Vagrant box name (excluding `.box` extension) that will be used to build a
 virtual machine.
 If it does not exist on the system - it will be downloaded from [:boxurlprefix](#boxurlprefix).
 
-####`cpus`
+#### `cpus`
 Currently undocumented.
 
-####`memory`
+#### `memory`
 Currently undocumented.
 
-####`disks`
+#### `disks`
 Currently undocumented.
 
-####`disksize`
+#### `disksize`
 Currently undocumented.
 
-####`boxurlprefix`
+#### `boxurlprefix`
 URL pointing to a location that contains Vagrant box files.
 It points to https://dl.fedoraproject.org/pub/alt/purpleidea/vagrant/ by
 default.
 
-####`sync`
+#### `sync`
 Sync type to use. Valid types include `rsync` and `nfs` (version 3). Other
 types, including `nfsv4` and `9p`, will hopefully be supported in the future.
 
-####`syncdir`
+#### `syncdir`
 This option sets where your project folder gets synced into the machine. If you
 pass an absolute path, that will be used, if you pass a relative path, then that
 will be appended to the default path for that environment. In general, you will
@@ -379,7 +379,7 @@ For example, if you have a project (a git repository perhaps) named `mgmt`, and
 you want to sync the files into `/vagrant/mgmt/`, then the special `/` path is
 the magic feature you're looking for.
 
-####`syncsrc`
+#### `syncsrc`
 Set the sync source for your vm. When left with the empty string `''`, this
 defaults to the [`folder`](#folder) in your project directory. When
 [`folder`](#folder) is empty, obviously the project directory is used by itself.
@@ -388,13 +388,13 @@ will pick the parent directory. This is a common hack for projects which hide
 the _mess_ of their project inside the [`folder`](#folder) variable, but want
 the whole project to get synchronized into the machine.
 
-####`folder`
+#### `folder`
 Currently undocumented.
 
-####`extern`
+#### `extern`
 Currently undocumented.
 
-####`cd`
+#### `cd`
 If you set this to a string, the `cd` command will run with this arg after
 `vscreen` connects to your vm, but before the `screen` command runs. This will
 have the effect of putting you in your favourite working directory
@@ -403,34 +403,34 @@ the `cd` value to `$SYNCDIR` (a string literal) or to `-` (the dash) then these
 are magic variables which indicate you want to cd to whichever path the
 [`syncdir`](#syncdir) option resolves to.
 
-####`puppet`
+#### `puppet`
 Currently undocumented.
 
-####`classes`
+#### `classes`
 Currently undocumented.
 
-####`shell`
+#### `shell`
 Currently undocumented.
 
-####`docker`
+#### `docker`
 Currently undocumented.
 
-####`kubernetes`
+#### `kubernetes`
 Currently undocumented.
 
-####`ansible`
+#### `ansible`
 Currently undocumented.
 
-####`playbook`
+#### `playbook`
 Currently undocumented.
 
-####`ansible_extras`
+#### `ansible_extras`
 Currently undocumented.
 
-####`cachier`
+#### `cachier`
 Currently undocumented.
 
-####`vms`
+#### `vms`
 By default, oh-my-vagrant will create [:count](#count) number of virtual
 machines, all with the same settings, and generated hostnames and IP addresses.
 Using the `:vms` array you can define different parameters for different VMs.
@@ -461,7 +461,7 @@ create `:count` extra VMs, which you might want or not, depending on your setup.
 See [this comment](https://github.com/purpleidea/oh-my-vagrant/pull/122#issuecomment-136054512)
 for an example situation where this might be useful.
 
-####`namespace`
+#### `namespace`
 Free-form string that will be used as:
 
 * Libvirt/VirtualBox virtual network name
@@ -471,7 +471,7 @@ Free-form string that will be used as:
 If you set this to the same string as an existing network name - make sure you
 also set [:network](#network) parameter correctly.
 
-####`count`
+#### `count`
 Set this to the number of virtual machines you want oh-my-vagrant to create.
 Hostnames and IP addresses will be generated automatically, and fair defaults
 will be used for the VMs.
@@ -486,13 +486,13 @@ Above configuration will create 5 virtual machines: testing-omv1, testing-omv2
 See also [:vms](#vms) parameter documentation for information about how you can
 define various virtual machine parameters yourself.
 
-####`username`
+#### `username`
 Currently undocumented.
 
-####`password`
+#### `password`
 Currently undocumented.
 
-####`poolid`
+#### `poolid`
 
 Array of [Red Hat Subscription Manager pool(s)](https://access.redhat.com/documentation/en-US/Red_Hat_Subscription_Management/1/html-single/RHSM/#subscr-about-pools)
 to attach to a system.
@@ -511,7 +511,7 @@ If you want to pass `--auto` parameter to subscription-manager command, set
 :poolid: auto
 ```
 
-####`repos`
+#### `repos`
 
 Array of [Red Hat Subscription Manager repositories](https://access.redhat.com/documentation/en-US/Red_Hat_Subscription_Management/1/html-single/RHSM/#entitlements-and-yum)
 to add to a system.
@@ -537,29 +537,29 @@ subscription-manager repos --enable 'repo2'
 subscription-manager repos --enable '...'
 ```
 
-####`update`
+#### `update`
 Currently undocumented.
 
-####`reboot`
+#### `reboot`
 Currently undocumented.
 
-####`unsafe`
+#### `unsafe`
 Set this to true if you want to use KVM's unsafe cache mode. If you do this, you
 will trade data integrity on your development environment's filesystem for a
 noticeable speed boost. See http://libvirt.org/formatdomain.html#elementsDisks
 
-####`nested`
+#### `nested`
 Currently undocumented.
 
-####`comment`
+#### `comment`
 A space to store a string comment of your choosing. This field is not currently
 used anywhere by Oh-My-Vagrant.
 
-####`reallyrm`
+#### `reallyrm`
 You probably shouldn't play with this unless you've read and understand the
 source.
 
-###Command line
+### Command line
 The command line arguments are currently undocumented. If you'd like to help
 improve these, please send a patch. They are not critical to Oh-My-Vagrant
 usage, because all operations can be done by editing the omv.yaml
@@ -567,27 +567,27 @@ configuration file. Using the command line does make using Oh-My-Vagrant a lot
 faster if you're constantly changing your environment. It also makes people say
 "Whoa!".
 
-####`--vagrant-help`
+#### `--vagrant-help`
 This option doesn't yet exist. To add it, please send in a patch!
 
-###oh-my-vagrant.yaml
+### oh-my-vagrant.yaml
 This is a user specific configuration file which typically goes in
 `~/.oh-my-vagrant.yaml` or in `~/config/oh-my-vagrant.yaml` if using a sane
 default xdg configuration.
 
-####username
+#### username
 Currently undocumented.
 
-####password
+#### password
 Currently undocumented.
 
-##Examples
+## Examples
 For example configurations, please consult the [examples/](https://github.com/purpleidea/oh-my-vagrant/tree/master/examples) directory in the git
 source repository. It is available from:
 
 [https://github.com/purpleidea/oh-my-vagrant/tree/master/examples](https://github.com/purpleidea/oh-my-vagrant/tree/master/examples)
 
-##Limitations
+## Limitations
 This project will work with Vagrant version 1.6.5 and greater. It may work with
 certain older versions of vagrant, but they are no longer tested. Hopefully new
 versions of Vagrant don't introduce any regressions that break this project.
@@ -617,7 +617,7 @@ platforms has been minimal due to lack of time and resources.
 Testing is community supported! Please report any issues as there are a lot of
 features, and in particular, support for additional distros isn't well tested.
 
-##Development
+## Development
 
 This is my personal project that I work on in my free time.
 Donations of funding, hardware, virtual machines, and other resources are
@@ -628,7 +628,7 @@ You can follow along [on my technical blog](https://ttboj.wordpress.com/).
 
 To report any bugs, please file a ticket at: [https://github.com/purpleidea/oh-my-vagrant/issues](https://github.com/purpleidea/oh-my-vagrant/issues).
 
-##Authors
+## Authors
 
 Copyright (C) 2012-2015+ James Shubin and the Oh-My-Vagrant contributors
 


### PR DESCRIPTION
This fixes the header markdown ``###`` by adding space between ``#`` and the following word.